### PR TITLE
allow cors to correctly load ptt.cc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,33 @@
 # ptt登入爬蟲
 
-利用Node.js+ GoogleChrome/puppeteer https://github.com/GoogleChrome/puppeteer
-至 https://term.ptt.cc/ 進行登入後隨即登出，
-配合pm2設置排程可用來做每日登入。
+利用 Node.js + [GoogleChrome/puppeteer](https://github.com/GoogleChrome/puppeteer)
+至 https://term.ptt.cc/ 進行登入後隨即登出，配合pm2設置排程可用來做每日登入。
 
 
 # 使用說明
 
 ## Init/建立檔案
 
-1. env未加入git，請參考.env.sample
+1. env 未加入 git，請參考 .env.sample
+
 2. yarn install or npm install 安裝node套件
 
+    * 如果你遭遇 node-gyp build 失敗的問題，嘗試安裝 python 2.7 後
+
+        ``` shell
+        npm config set python python2.7
+        npm install
+        ```
 
 ## 使用的套件
+ 
  - puppeteer
+ 
  - sleep
+ 
  - dotenv
- 
- 
+
+
 ## 執行
 
 ```shell
@@ -26,4 +35,5 @@ node start
 ```
 
 ## Demo
-<img src="https://i.imgur.com/3tfzD7O.png">
+
+![](https://i.imgur.com/3tfzD7O.png)

--- a/chromium.js
+++ b/chromium.js
@@ -17,9 +17,15 @@ const chromium = {
     init: async () => {
         if (browser) return browser
 
-        const config = (process.env.ENVIRONMENT == 0) ? { devtools: true } : { devtools: false};
+        const useDevTools = (process.env.ENVIRONMENT == 0);
+        const config = {
+            args: [
+                '--disable-web-security',
+            ],
+            devtools: useDevTools,
+        }
 
-        browser = await puppeteer.launch(config);
+        browser = await puppeteer.launch(config);        
         return browser
     },
     get browser() {


### PR DESCRIPTION
[Here I join you.](https://hacktoberfest.digitalocean.com/)


似乎是因為 puppeteer 因為 CORS 政策擋下了 jquery, bootstrap 等外部資源，導致 term.ptt.cc 無法正確呈現，所以直接把 CORS 關掉了。

我有稍微把 readme 調一下排版，希望你不會介意。如果你會介意我在修改！